### PR TITLE
Expanded with explicit assert support to print the failing expression.

### DIFF
--- a/matches/Cargo.toml
+++ b/matches/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
-
 name = "matches"
 version = "0.1.2"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT"
 repository = "https://github.com/SimonSapin/rust-std-candidates"
 description = "A macro to evaluate, as a boolean, whether an expression matches a pattern."
-
 
 [lib]
 name = "matches"

--- a/matches/lib.rs
+++ b/matches/lib.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! matches {
-    ($expression: expr, $($pattern:tt)+) => {
-        _tt_as_expr_hack! {
+    ($expression:expr, $($pattern:tt)+) => {
+        _matches_tt_as_expr_hack! {
             match $expression {
                 $($pattern)+ => true,
                 _ => false
@@ -10,19 +10,53 @@ macro_rules! matches {
     }
 }
 
-
 /// Work around "error: unexpected token: `an interpolated tt`", whatever that means.
 #[macro_export]
-macro_rules! _tt_as_expr_hack {
+macro_rules! _matches_tt_as_expr_hack {
     ($value:expr) => ($value)
 }
 
+#[macro_export]
+macro_rules! assert_matches {
+    ($expression:expr, $($pattern:tt)+) => {
+        _matches_tt_as_expr_hack! {
+            match $expression {
+                $($pattern)+ => (),
+                ref e => panic!("assertion failed: `{:?}` does not match `{}`", e, stringify!($($pattern)+)),
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! debug_assert_matches {
+    ($($arg:tt)*) => (if cfg!(debug_assertions) { assert_matches!($($arg)*); })
+}
 
 #[test]
-fn it_works() {
+fn matches_works() {
     let foo = Some("-12");
     assert!(matches!(foo, Some(bar) if
         matches!(bar.as_bytes()[0], b'+' | b'-') &&
         matches!(bar.as_bytes()[1], b'0'...b'9')
     ));
+}
+
+#[test]
+fn assert_matches_works() {
+    let foo = Some("-12");
+    assert_matches!(foo, Some(bar) if
+        matches!(bar.as_bytes()[0], b'+' | b'-') &&
+        matches!(bar.as_bytes()[1], b'0'...b'9')
+    );
+}
+
+#[test]
+#[should_panic(expected = "assertion failed: `Some(\"-AB\")` does not match ")]
+fn assert_matches_panics() {
+    let foo = Some("-AB");
+    assert_matches!(foo, Some(bar) if
+        matches!(bar.as_bytes()[0], b'+' | b'-') &&
+        matches!(bar.as_bytes()[1], b'0'...b'9')
+    );
 }


### PR DESCRIPTION
Renamed `_tt_as_expr_hack` to be more crate specific to avoid potential conflicts: I tried scoping it with `$crate::` but that doesn't appear to work for macros...

Added tests for the new macros.