### PR TITLE
Update matches for Rust 1.12 and add documentation

### DIFF
--- a/matches/Cargo.toml
+++ b/matches/Cargo.toml
@@ -10,4 +10,3 @@ documentation = "https://docs.rs/matches/"
 [lib]
 name = "matches"
 path = "lib.rs"
-doctest = false

--- a/matches/Cargo.toml
+++ b/matches/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT"
 repository = "https://github.com/SimonSapin/rust-std-candidates"
 description = "A macro to evaluate, as a boolean, whether an expression matches a pattern."
+documentation = "https://docs.rs/matches/"
 
 [lib]
 name = "matches"

--- a/matches/lib.rs
+++ b/matches/lib.rs
@@ -1,3 +1,32 @@
+/// Check if an expression matches a refutable pattern.
+///
+/// Syntax: `matches!(` *expression* `,` *pattern* `)`
+///
+/// Return a boolean, true if the expression matches the pattern, false otherwise.
+///
+/// # Examples
+///
+/// ```
+/// #[macro_use]
+/// extern crate matches;
+///
+/// pub enum Foo<T> {
+///     A,
+///     B(T),
+/// }
+///
+/// impl<T> Foo<T> {
+///     pub fn is_a(&self) -> bool {
+///         matches!(*self, Foo::A)
+///     }
+///
+///     pub fn is_b(&self) -> bool {
+///         matches!(*self, Foo::B(_))
+///     }
+/// }
+///
+/// # fn main() { }
+/// ```
 #[macro_export]
 macro_rules! matches {
     ($expression:expr, $($pattern:tt)+) => {
@@ -8,6 +37,24 @@ macro_rules! matches {
     }
 }
 
+/// Assert that an expression matches a refutable pattern.
+///
+/// Syntax: `assert_matches!(` *expression* `,` *pattern* `)`
+///
+/// Panic with a message that shows the expression if it does not match the
+/// pattern.
+///
+/// # Examples
+///
+/// ```
+/// #[macro_use]
+/// extern crate matches;
+///
+/// fn main() {
+///     let data = [1, 2, 3];
+///     assert_matches!(data.get(1), Some(_));
+/// }
+/// ```
 #[macro_export]
 macro_rules! assert_matches {
     ($expression:expr, $($pattern:tt)+) => {
@@ -18,6 +65,26 @@ macro_rules! assert_matches {
     }
 }
 
+/// Assert that an expression matches a refutable pattern using debug assertions.
+///
+/// Syntax: `debug_assert_matches!(` *expression* `,` *pattern* `)`
+///
+/// If debug assertions are enabled, panic with a message that shows the
+/// expression if it does not match the pattern.
+///
+/// When debug assertions are not enabled, this macro does nothing.
+///
+/// # Examples
+///
+/// ```
+/// #[macro_use]
+/// extern crate matches;
+///
+/// fn main() {
+///     let data = [1, 2, 3];
+///     debug_assert_matches!(data.get(1), Some(_));
+/// }
+/// ```
 #[macro_export]
 macro_rules! debug_assert_matches {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { assert_matches!($($arg)*); })

--- a/matches/lib.rs
+++ b/matches/lib.rs
@@ -1,29 +1,19 @@
 #[macro_export]
 macro_rules! matches {
     ($expression:expr, $($pattern:tt)+) => {
-        _matches_tt_as_expr_hack! {
-            match $expression {
-                $($pattern)+ => true,
-                _ => false
-            }
+        match $expression {
+            $($pattern)+ => true,
+            _ => false
         }
     }
-}
-
-/// Work around "error: unexpected token: `an interpolated tt`", whatever that means.
-#[macro_export]
-macro_rules! _matches_tt_as_expr_hack {
-    ($value:expr) => ($value)
 }
 
 #[macro_export]
 macro_rules! assert_matches {
     ($expression:expr, $($pattern:tt)+) => {
-        _matches_tt_as_expr_hack! {
-            match $expression {
-                $($pattern)+ => (),
-                ref e => panic!("assertion failed: `{:?}` does not match `{}`", e, stringify!($($pattern)+)),
-            }
+        match $expression {
+            $($pattern)+ => (),
+            ref e => panic!("assertion failed: `{:?}` does not match `{}`", e, stringify!($($pattern)+)),
         }
     }
 }


### PR DESCRIPTION
- Remove tt hack, requires Rust 1.12+
  - This has the benefit that no invisible macros pollute, and the user can use selective macro import (`#[macro_use(matches)]`)
- Add documentation