### PR TITLE
Add unwrap_match! macro which is a general unwrap for enums

### DIFF
--- a/matches/Cargo.toml
+++ b/matches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matches"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT"
 repository = "https://github.com/SimonSapin/rust-std-candidates"

--- a/matches/lib.rs
+++ b/matches/lib.rs
@@ -68,7 +68,7 @@ macro_rules! unwrap_match {
         _matches_tt_as_expr_hack! {
             match $expression {
                 $($pattern)+,
-                _ => panic!("pattern passed to unwrap_match! did not match"),
+                _ => panic!("pattern {} passed to unwrap_match! did not match", stringify!($($pattern)+)),
             }
         }
     }
@@ -178,7 +178,7 @@ fn unwrap_match_works() {
 }
 
 #[test]
-#[should_panic(expected = "pattern passed to unwrap_match! did not match")]
+#[should_panic(expected = "pattern Foo :: A ( i ) => i passed to unwrap_match! did not match")]
 fn unwrap_match_panics() {
     #[allow(dead_code)]
     enum Foo {


### PR DESCRIPTION
example:
```rust
	enum E {
		A(u32),
		B,
	}

	let e = E::A(2);
	assert_eq!(unwrap_match!(e, E::A(i) => i), 2);
```

I realise that you might not accept this, since it is not a part of the RFC, however I believe that this is a very useful feature.