### PR TITLE
Improvements to assert_matches

### DIFF
--- a/matches/Cargo.toml
+++ b/matches/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 repository = "https://github.com/SimonSapin/rust-std-candidates"
 description = "A macro to evaluate, as a boolean, whether an expression matches a pattern."
 documentation = "https://docs.rs/matches/"
+edition = "2018"
 
 [lib]
 name = "matches"

--- a/matches/tests/macro_use_one.rs
+++ b/matches/tests/macro_use_one.rs
@@ -1,11 +1,10 @@
-// https://github.com/SimonSapin/rust-std-candidates/issues/12
-#[macro_use(matches)] extern crate matches;
+use matches::matches;
 
 #[test]
 fn matches_works() {
     let foo = Some("-12");
     assert!(matches!(foo, Some(bar) if
         matches!(bar.as_bytes()[0], b'+' | b'-') &&
-        matches!(bar.as_bytes()[1], b'0'...b'9')
+        matches!(bar.as_bytes()[1], b'0'..=b'9')
     ));
 }


### PR DESCRIPTION
- assert_matches now optionally accepts a block, which is run in the event the match succeeds. This allows for running additional assertions against the matched pattern.
- Updated matches to Edition 2018
- Improved macro match patterns; replaced `$(tt)+` with more specific matcher types
- Added additional tests and documentation for this new feature