### PR TITLE
Make `matches` crate `no_std` compatible

### DIFF
--- a/matches/Cargo.toml
+++ b/matches/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 license = "MIT"
 repository = "https://github.com/SimonSapin/rust-std-candidates"

--- a/matches/lib.rs
+++ b/matches/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 /// Check if an expression matches a refutable pattern.
 ///
 /// Syntax: `matches!(` *expression* `,` *pattern* `)`


### PR DESCRIPTION
I wanted to make the [`url`](https://github.com/servo/rust-url) crate `no_std` compatible, but since their MSRV is 1.36, they still use this crate, and hence is blocked here.

Another option is to not do this and just wait until `url` bumps their MSRV, or remove usage of the `matches!` macro from `url`.